### PR TITLE
Support difference package managers

### DIFF
--- a/src/Dutchskull.Aspire.PolyRepo.AppHost/Dutchskull.Aspire.PolyRepo.AppHost.csproj
+++ b/src/Dutchskull.Aspire.PolyRepo.AppHost/Dutchskull.Aspire.PolyRepo.AppHost.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.1" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.1" />
-    <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.0.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.2.0" />
+    <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Dutchskull.Aspire.PolyRepo.ServiceDefaults/Dutchskull.Aspire.PolyRepo.ServiceDefaults.csproj
+++ b/src/Dutchskull.Aspire.PolyRepo.ServiceDefaults/Dutchskull.Aspire.PolyRepo.ServiceDefaults.csproj
@@ -11,7 +11,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.5.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />

--- a/src/Dutchskull.Aspire.PolyRepo.Tests.E2E/Dutchskull.Aspire.PolyRepo.Tests.E2E.csproj
+++ b/src/Dutchskull.Aspire.PolyRepo.Tests.E2E/Dutchskull.Aspire.PolyRepo.Tests.E2E.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="8.0.1" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="8.2.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Dutchskull.Aspire.PolyRepo.Web/Dutchskull.Aspire.PolyRepo.Web.csproj
+++ b/src/Dutchskull.Aspire.PolyRepo.Web/Dutchskull.Aspire.PolyRepo.Web.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="8.0.1" />
+    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="8.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Dutchskull.Aspire.PolyRepo/Dutchskull.Aspire.PolyRepo.csproj
+++ b/src/Dutchskull.Aspire.PolyRepo/Dutchskull.Aspire.PolyRepo.csproj
@@ -35,8 +35,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-        <PackageReference Include="Aspire.Hosting" Version="8.0.1" />
-        <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.0.1" />
+        <PackageReference Include="Aspire.Hosting" Version="8.2.0" />
+        <PackageReference Include="Aspire.Hosting.NodeJs" Version="8.2.0" />
         <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
     </ItemGroup>
 

--- a/src/Dutchskull.Aspire.PolyRepo/Interfaces/IProcessCommandExecutor.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/Interfaces/IProcessCommandExecutor.cs
@@ -6,7 +6,8 @@ public interface IProcessCommandExecutor
 
     void CloneGitRepository(string gitUrl, string resolvedRepositoryPath, string? branch = null);
 
-    int NpmInstall(string resolvedRepositoryPath);
+    int NpmInstall(string resolvedRepositoryPath, string? installerArguments = null,
+        PackageManager packageManager = PackageManager.Npm);
 
     void PullAndResetRepository(string repositoryConfigRepositoryPath);
 }

--- a/src/Dutchskull.Aspire.PolyRepo/PackageManager.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/PackageManager.cs
@@ -1,0 +1,8 @@
+﻿namespace Dutchskull.Aspire.PolyRepo;
+
+public enum PackageManager
+{
+    Npm,
+    Pnpm,
+    Yarn
+}

--- a/src/Dutchskull.Aspire.PolyRepo/ProcessCommandExecutor.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/ProcessCommandExecutor.cs
@@ -14,8 +14,18 @@ public class ProcessCommandExecutor : IProcessCommandExecutor
         Repository.Clone(gitUrl, resolvedRepositoryPath, new CloneOptions { BranchName = branch });
     }
 
-    public int NpmInstall(string resolvedRepositoryPath) =>
-        RunProcess("cmd.exe", $"/C cd {resolvedRepositoryPath} && npm i");
+    public int NpmInstall(string resolvedRepositoryPath, string? installerArguments = null,
+        PackageManager packageManager = PackageManager.Npm) =>
+        packageManager switch
+        {
+            PackageManager.Npm => RunProcess("cmd.exe",
+                $"/C cd {resolvedRepositoryPath} && npm i {installerArguments}"),
+            PackageManager.Pnpm => RunProcess("cmd.exe",
+                $"/C cd {resolvedRepositoryPath} && pnpm i {installerArguments}"),
+            PackageManager.Yarn => RunProcess("cmd.exe",
+                $"/C cd {resolvedRepositoryPath} && yarn {installerArguments}"),
+            _ => RunProcess("cmd.exe", $"/C cd {resolvedRepositoryPath} && npm i {installerArguments}"),
+        };
 
     public void PullAndResetRepository(string repositoryConfigRepositoryPath)
     {

--- a/src/Dutchskull.Aspire.PolyRepo/ProcessCommandExecutor.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/ProcessCommandExecutor.cs
@@ -23,7 +23,7 @@ public class ProcessCommandExecutor : IProcessCommandExecutor
             PackageManager.Pnpm => RunProcess("cmd.exe",
                 $"/C cd {resolvedRepositoryPath} && pnpm i {installerArguments}"),
             PackageManager.Yarn => RunProcess("cmd.exe",
-                $"/C cd {resolvedRepositoryPath} && yarn {installerArguments}"),
+                $"/C cd {resolvedRepositoryPath} && yarn install {installerArguments}"),
             _ => RunProcess("cmd.exe", $"/C cd {resolvedRepositoryPath} && npm i {installerArguments}"),
         };
 

--- a/src/Dutchskull.Aspire.PolyRepo/ProjectResourceBuilderExtensions.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/ProjectResourceBuilderExtensions.cs
@@ -36,10 +36,13 @@ public static class ProjectResourceBuilderExtensions
         IResourceBuilder<RepositoryResource> repository,
         string relativeProjectPath,
         string scriptName = "start",
-        string[]? args = null)
+        string[]? args = null,
+        PackageManager packageManager = PackageManager.Npm,
+        string? packageManagerArguments = null)
     {
         string projectPath = repository.Resource.Resolve(relativeProjectPath);
-        repository.Resource.RepositoryConfig?.ProcessCommandsExecutor.NpmInstall(projectPath);
+        repository.Resource.RepositoryConfig?.ProcessCommandsExecutor.NpmInstall(projectPath, packageManagerArguments,
+            packageManager);
 
         return builder.AddNpmApp(name, projectPath, scriptName, args);
     }
@@ -50,11 +53,13 @@ public static class ProjectResourceBuilderExtensions
         IResourceBuilder<RepositoryResource> repository,
         string relativeProjectPath,
         string? workingDirectory = null,
-        string[]? args = null)
+        string[]? args = null,
+        PackageManager packageManager = PackageManager.Npm,
+        string? packageManagerArguments = null)
     {
         string projectPath = repository.Resource.Resolve(relativeProjectPath);
-        repository.Resource.RepositoryConfig?.ProcessCommandsExecutor.NpmInstall(projectPath);
-
+        repository.Resource.RepositoryConfig?.ProcessCommandsExecutor.NpmInstall(projectPath, packageManagerArguments,
+            packageManager);
         return builder.AddNodeApp(name, projectPath, workingDirectory, args);
     }
 }


### PR DESCRIPTION
I assume not everyone will be using NPM for their Node projects. As well, I assume not everyone will be able to use `npm i` to install Node projects. So, this PR is designed to support the main three (NPM, PNPM, Yarn) as well as custom installer arguments, such as `--force` for PNPM.

I'm newer to the dotnet space, so this may not be "correct", so feel free to provide constructive criticism or change anything you'd like changed!

Note: My PC *refused* to install Aspire 8.0.1, so I had to install 8.2.0 and update the project as such. It doesn't *need* to be updated, however.