### PR TITLE
Add CustomHeaders property to enable basic authorization header when fetching from Azure DevOps Repos

### DIFF
--- a/src/Dutchskull.Aspire.PolyRepo/GitConfig.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/GitConfig.cs
@@ -11,4 +11,6 @@ public record GitConfig
     public required string Username { get; init; }
 
     public required string Password { get; init; }
+
+    public string[] CustomHeaders { get; init; } = [];
 }

--- a/src/Dutchskull.Aspire.PolyRepo/GitConfigBuilder.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/GitConfigBuilder.cs
@@ -5,6 +5,7 @@ public class GitConfigBuilder
     private string? _password;
     private string? _url;
     private string? _username;
+    private string[]? _customHeaders;
 
     internal GitConfigBuilder WithUrl(string url)
     {
@@ -21,6 +22,12 @@ public class GitConfigBuilder
         return this;
     }
 
+    public GitConfigBuilder WithCustomHeaders(params string[] headers)
+    {
+        _customHeaders = headers;
+        return this;
+    }
+
     public GitConfig Build()
     {
         if (string.IsNullOrEmpty(_username))
@@ -33,11 +40,14 @@ public class GitConfigBuilder
             _password = string.Empty;
         }
 
+        _customHeaders ??= [];
+
         return new GitConfig
         {
             Url = _url,
             Username = _username,
-            Password = _password
+            Password = _password,
+            CustomHeaders = _customHeaders
         };
     }
 }

--- a/src/Dutchskull.Aspire.PolyRepo/ProcessCommandExecutor.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/ProcessCommandExecutor.cs
@@ -20,7 +20,9 @@ public class ProcessCommandExecutor : IProcessCommandExecutor
                 {
                     Username = gitConfig.Username,
                     Password = gitConfig.Password
-                }
+                    
+                },
+                CustomHeaders = gitConfig.CustomHeaders
             }
         };
 
@@ -46,7 +48,8 @@ public class ProcessCommandExecutor : IProcessCommandExecutor
             {
                 Username = gitConfig.Username,
                 Password = gitConfig.Password
-            }
+            },
+            CustomHeaders = gitConfig.CustomHeaders
         };
 
         IEnumerable<string> references = remote.FetchRefSpecs.Select(x => x.Specification);


### PR DESCRIPTION
Add CustomHeaders property to enable basic authorization header when fetching from Azure DevOps Repos (TFS).

Tried to use the WithAuthentication method but was receiving the following error :

![image](https://github.com/user-attachments/assets/45456a62-c56b-4a5b-a6c6-2271c760f098)

After looking around in StackOverflow / libgit2sharp githubt I found a solution where you can pass a Basic Auth header.

https://github.com/libgit2/libgit2sharp/issues/1596

With this change I was able to clone the repository using a Personal Access Token.

This is my first time contributing, if you need more information, please let me know.

