### PR TITLE
Update BuildDotNetProject and AddProjectFromRepository to support optional build arguments

### DIFF
--- a/src/Dutchskull.Aspire.PolyRepo/Interfaces/IProcessCommandExecutor.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/Interfaces/IProcessCommandExecutor.cs
@@ -2,7 +2,7 @@
 
 public interface IProcessCommandExecutor
 {
-    int BuildDotNetProject(string resolvedProjectPath);
+    int BuildDotNetProject(string resolvedProjectPath, string[]? args);
 
     void CloneGitRepository(GitConfig gitConfig, string resolvedRepositoryPath, string? branch = null);
 

--- a/src/Dutchskull.Aspire.PolyRepo/ProcessCommandExecutor.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/ProcessCommandExecutor.cs
@@ -7,7 +7,17 @@ namespace Dutchskull.Aspire.PolyRepo;
 
 public class ProcessCommandExecutor : IProcessCommandExecutor
 {
-    public int BuildDotNetProject(string resolvedProjectPath) => RunProcess("dotnet", $"build {resolvedProjectPath}");
+    public int BuildDotNetProject(string resolvedProjectPath, string[]? args = null)
+    {
+        string arguments = $"build {resolvedProjectPath}";
+
+        if (args != null && args.Length > 0)
+        {
+            arguments = $"{arguments} {string.Join(" ", args)}";
+        }
+
+        return RunProcess("dotnet", arguments);
+    }
 
     public void CloneGitRepository(GitConfig gitConfig, string resolvedRepositoryPath, string? branch = null)
     {
@@ -20,7 +30,7 @@ public class ProcessCommandExecutor : IProcessCommandExecutor
                 {
                     Username = gitConfig.Username,
                     Password = gitConfig.Password
-                    
+
                 },
                 CustomHeaders = gitConfig.CustomHeaders
             }

--- a/src/Dutchskull.Aspire.PolyRepo/ProjectResourceBuilderExtensions.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/ProjectResourceBuilderExtensions.cs
@@ -22,10 +22,11 @@ public static class ProjectResourceBuilderExtensions
         this IDistributedApplicationBuilder builder,
         string name,
         IResourceBuilder<RepositoryResource> repository,
-        string relativeProjectPath)
+        string relativeProjectPath,
+        string[]? buildArgs = null)
     {
         string projectPath = repository.Resource.Resolve(relativeProjectPath);
-        repository.Resource.RepositoryConfig?.ProcessCommandsExecutor.BuildDotNetProject(projectPath);
+        repository.Resource.RepositoryConfig?.ProcessCommandsExecutor.BuildDotNetProject(projectPath, buildArgs);
 
         return builder.AddProject(name, projectPath);
     }


### PR DESCRIPTION
Extended the BuildDotNetProject method to accept optional arguments, enabling more flexible dotnet build command execution. Updated method calls and interfaces accordingly to pass these build arguments when provided. This enhancement improves customization and adaptability in build processes.

// Without arguments (backward compatible)
executor.BuildDotNetProject("path/to/project");

// With arguments
executor.BuildDotNetProject("path/to/project", new[] { "/p:Configuration=Release", "/p:Platform=x64" });