### PR TITLE
Update dependabot.yml to remove Aspire ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,5 +17,3 @@ updates:
     ignore:
       - dependency-name: "FluentAssertions"
         versions: [ ">=8.0.0" ]
-      - dependency-name: "Aspire*"
-        versions: [ ">=9.0.0" ]


### PR DESCRIPTION
Removed ignore rule for Aspire dependencies.