### PR TITLE
Added git url validation for Azure DevOps repositories

### DIFF
--- a/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitRepositoryConfigBuilderTests.cs
+++ b/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitRepositoryConfigBuilderTests.cs
@@ -66,6 +66,22 @@ public class GitRepositoryConfigBuilderTests
     }
 
     [Fact]
+    public void BuildConfig_ShouldUseDecodedRepositoryName_ForAzureDevOpsUrls()
+    {
+        // Arrange
+        const string gitUrl = "https://dev.azure.com/example/example%20web%20site/_git/example%20web%20site";
+
+        RepositoryConfigBuilder builder = new RepositoryConfigBuilder()
+            .WithGitUrl(gitUrl);
+
+        // Act
+        RepositoryConfig config = builder.Build();
+
+        // Assert
+        config.RepositoryPath.Should().Be(Path.Combine(Path.GetFullPath("."), "example web site"));
+    }
+
+    [Fact]
     public void WithCloneTargetPath_ShouldSetCloneTargetPath()
     {
         // Arrange

--- a/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitUrlUtilitiesTests.cs
+++ b/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitUrlUtilitiesTests.cs
@@ -10,6 +10,8 @@ public class GitUrlUtilitiesTests
     [Theory]
     [InlineData("https://github.com/example/repo.git", true)]
     [InlineData("https://github.com/example/repo", false)]
+    [InlineData("https://example@dev.azure.com/example/example%20web%20site/_git/example%20web%20site", true)]
+    [InlineData("git@ssh.dev.azure.com:v3/example/example%20web%20site/example%20web%20site", true)]
     [InlineData("git@github.com:example/repo", false)]
     [InlineData("git://github.com/example/repo", false)]
     [InlineData("https://example.com", false)]

--- a/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitUrlUtilitiesTests.cs
+++ b/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitUrlUtilitiesTests.cs
@@ -65,6 +65,7 @@ public class GitUrlUtilitiesTests
     [Theory]
     [InlineData(AzureDevOpsGitUrl)]
     [InlineData("https://dev.azure.com/example/example%20web%20site/_git/example%20web%20site/")]
+    [InlineData("git@ssh.dev.azure.com:v3/example/example%20web%20site/example%20web%20site")]
     public void GetProjectNameFromGitUrl_ShouldDecodePercentEncodedRepositoryNames(string gitUrl)
     {
         // Act

--- a/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitUrlUtilitiesTests.cs
+++ b/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitUrlUtilitiesTests.cs
@@ -11,6 +11,8 @@ public class GitUrlUtilitiesTests
     [InlineData("https://github.com/example/repo.git", true)]
     [InlineData("https://github.com/example/repo", false)]
     [InlineData("https://example@dev.azure.com/example/example%20web%20site/_git/example%20web%20site", true)]
+    [InlineData("https://dev.azure.com/example/example%20web%20site/_git/example%20web%20site", true)]
+    [InlineData("https://dev.azure.com/example/example%20web%20site/_git/example%20web%20site/", true)]
     [InlineData("git@ssh.dev.azure.com:v3/example/example%20web%20site/example%20web%20site", true)]
     [InlineData("git@github.com:example/repo", false)]
     [InlineData("git://github.com/example/repo", false)]

--- a/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitUrlUtilitiesTests.cs
+++ b/src/Dutchskull.Aspire.PolyRepo.Tests.Unit/GitUrlUtilitiesTests.cs
@@ -6,6 +6,7 @@ public class GitUrlUtilitiesTests
 {
     private const string GitUrl = "https://github.com/example/repo.git";
     private const string ExpectedProjectName = "repo";
+    private const string AzureDevOpsGitUrl = "https://dev.azure.com/example/example%20web%20site/_git/example%20web%20site";
 
     [Theory]
     [InlineData("https://github.com/example/repo.git", true)]
@@ -59,5 +60,27 @@ public class GitUrlUtilitiesTests
 
         // Assert
         projectName.Should().Be(ExpectedProjectName);
+    }
+
+    [Theory]
+    [InlineData(AzureDevOpsGitUrl)]
+    [InlineData("https://dev.azure.com/example/example%20web%20site/_git/example%20web%20site/")]
+    public void GetProjectNameFromGitUrl_ShouldDecodePercentEncodedRepositoryNames(string gitUrl)
+    {
+        // Act
+        string projectName = GitUrlUtilities.GetProjectNameFromGitUrl(gitUrl);
+
+        // Assert
+        projectName.Should().Be("example web site");
+    }
+
+    [Fact]
+    public void GetProjectNameFromGitUrl_ShouldThrow_WhenDecodedRepositoryNameContainsPathSeparators()
+    {
+        // Act
+        Action act = () => GitUrlUtilities.GetProjectNameFromGitUrl("https://dev.azure.com/example/project/_git/repository%2Fchild");
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
     }
 }

--- a/src/Dutchskull.Aspire.PolyRepo/GitUrlUtilities.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/GitUrlUtilities.cs
@@ -4,8 +4,23 @@ namespace Dutchskull.Aspire.PolyRepo;
 
 internal static partial class GitUrlUtilities
 {
-    internal static string GetProjectNameFromGitUrl(string gitUrl) => 
-        gitUrl.RemovePostfix(".git").Split('/')[^1];
+    internal static string GetProjectNameFromGitUrl(string gitUrl)
+    {
+        string normalizedGitUrl = gitUrl.TrimEnd('/').RemovePostfix(".git");
+        string encodedProjectName = normalizedGitUrl[(normalizedGitUrl.LastIndexOf('/') + 1)..];
+        string projectName = Uri.UnescapeDataString(encodedProjectName);
+
+        if (string.IsNullOrWhiteSpace(projectName) ||
+            projectName is "." or ".." ||
+            projectName.Contains('/') ||
+            projectName.Contains('\\') ||
+            projectName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException("Git URL resolved to an unsafe repository name.", nameof(gitUrl));
+        }
+
+        return projectName;
+    }
 
     internal static bool IsValidGitUrl(string url) =>
         !string.IsNullOrEmpty(url) && GitUrlRegex().IsMatch(url);

--- a/src/Dutchskull.Aspire.PolyRepo/GitUrlUtilities.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/GitUrlUtilities.cs
@@ -10,6 +10,6 @@ internal static partial class GitUrlUtilities
     internal static bool IsValidGitUrl(string url) =>
         !string.IsNullOrEmpty(url) && GitUrlRegex().IsMatch(url);
 
-    [GeneratedRegex(@"^(?:git|https?|git@[\w\.]+):\/\/[\w\.@\:\/\-~]+\.git(?:\/)?$")]
+    [GeneratedRegex(@"^(?:(?:git|https?):\/\/[^\s]+\.git(?:\/)?|https:\/\/(?:[\w.-]+@)?dev\.azure\.com\/[^\/\s]+\/[^\/\s]+\/_git\/[^\/\s]+(?:\/)?|git@ssh\.dev\.azure\.com:v3\/[^\/\s]+\/[^\/\s]+\/[^\/\s]+(?:\/)?)$")]
     private static partial Regex GitUrlRegex();
 }

--- a/src/Dutchskull.Aspire.PolyRepo/GitUrlUtilities.cs
+++ b/src/Dutchskull.Aspire.PolyRepo/GitUrlUtilities.cs
@@ -6,9 +6,24 @@ internal static partial class GitUrlUtilities
 {
     internal static string GetProjectNameFromGitUrl(string gitUrl)
     {
-        string normalizedGitUrl = gitUrl.TrimEnd('/').RemovePostfix(".git");
-        string encodedProjectName = normalizedGitUrl[(normalizedGitUrl.LastIndexOf('/') + 1)..];
-        string projectName = Uri.UnescapeDataString(encodedProjectName);
+        ReadOnlySpan<char> gitUrlSpan = gitUrl.AsSpan().TrimEnd('/');
+        int projectNameStart = gitUrlSpan.LastIndexOf('/');
+
+        if (projectNameStart < 0 || projectNameStart == gitUrlSpan.Length - 1)
+        {
+            throw new ArgumentException("Git URL could not be parsed.", nameof(gitUrl));
+        }
+
+        ReadOnlySpan<char> encodedProjectName = gitUrlSpan[(projectNameStart + 1)..];
+
+        if (encodedProjectName.EndsWith(".git", StringComparison.Ordinal))
+        {
+            encodedProjectName = encodedProjectName[..^4];
+        }
+
+        string projectName = encodedProjectName.Contains('%')
+            ? Uri.UnescapeDataString(encodedProjectName.ToString())
+            : encodedProjectName.ToString();
 
         if (string.IsNullOrWhiteSpace(projectName) ||
             projectName is "." or ".." ||


### PR DESCRIPTION
Azure DevOps repositories have a different format compared to GitHub urls. This update adds RegEx support for Azure DevOps repos, including support for spaces in project names.